### PR TITLE
Tx status 'removed-from-pool' removed and changed to 'pending'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 dist/
 exec/
 
+# temp build artifacts
+.version
 
 # Logs
 logs

--- a/src/model/state.ts
+++ b/src/model/state.ts
@@ -87,7 +87,7 @@ export interface EthereumTxStatus {
   SendTime: number; // UTC seconds
   GasPriceStrategy: GasPriceStrategy;
   GasPrice: number; // wei
-  Status: 'pending' | 'final' | 'failed-send' | 'timeout' | 'removed-from-pool' | 'revert'; // final according to ManagementEthRefBlock
+  Status: 'pending' | 'final' | 'failed-send' | 'timeout' | 'revert'; // final according to ManagementEthRefBlock
   TxHash: string;
   EthBlock: number;
   OnFinal?: () => void;

--- a/src/write/ethereum.test.ts
+++ b/src/write/ethereum.test.ts
@@ -369,7 +369,7 @@ test('readPendingTransactionStatus on a recent pending tx that becomes removed f
   await readPendingTransactionStatus(state.EthereumLastElectionsTx, state, exampleConfig);
 
   t.assert(state.EthereumLastElectionsTx.LastPollTime > 1400000000);
-  t.is(state.EthereumLastElectionsTx.Status, 'removed-from-pool');
+  t.is(state.EthereumLastElectionsTx.Status, 'pending'); // this used to return error
   t.is(state.EthereumConsecutiveTxTimeouts, 3);
   t.is(state.EthereumSuccessfulTxStats[getToday()], 1);
   t.is(arr.length, 0);

--- a/src/write/ethereum.ts
+++ b/src/write/ethereum.ts
@@ -131,12 +131,7 @@ export async function readPendingTransactionStatus(
 
   // needed since getTransactionReceipt fails on light client when tx is pending
   const tx = await state.web3.eth.getTransaction(status.TxHash);
-  if (tx == null) {
-    Logger.error(`Last ethereum ${status.Type} tx ${status.TxHash} removed from pool.`);
-    status.Status = 'removed-from-pool';
-    return;
-  }
-  if (tx.blockNumber == null) {
+  if (tx == null || tx.blockNumber == null) {
     Logger.log(`Last ethereum ${status.Type} tx ${status.TxHash} is still waiting for block.`);
     handlePendingTxTimeout(status, state, config);
     return; // still pending


### PR DESCRIPTION
‘removed-from-pool’ tx status changed because it caused false positives (query arrived to node who didn’t see the tx yet), and on false positive we would retransmit the tx