### PR TITLE
Increase invalid reputation grace time

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,7 @@ export const defaultConfiguration = {
   EthereumSyncRequirementSeconds: 20 * 60,
   FailToSyncVcsTimeoutSeconds: 24 * 60 * 60,
   ElectionsRefreshWindowSeconds: 2 * 60 * 60,
-  InvalidReputationGraceSeconds: 6 * 60 * 60,
+  InvalidReputationGraceSeconds: 30 * 60 * 60,
   VoteUnreadyValiditySeconds: 7 * 24 * 60 * 60,
   ElectionsAuditOnly: false,
   SuspendVoteUnready: true,


### PR DESCRIPTION
Increase invalid reputation grace time default config - set to 30hrs