### PR TITLE
Add ability to pass node config as environment variables for v3

### DIFF
--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -4,33 +4,100 @@ import { parseArgs } from './cli-args';
 import _ from 'lodash';
 import { exampleConfig } from './config.example';
 
-test.serial.afterEach.always(() => {
+let env: NodeJS.ProcessEnv;
+
+test.before(() => {
+  env = process.env;
+});
+
+test.beforeEach(() => {
+  process.env = { ...env };
+});
+
+test.afterEach.always(() => {
+  process.env = env;
   mockFs.restore();
 });
 
-test.serial('parseArgs default config file does not exist', (t) => {
+test('parseArgs with no config and no environment variables', (t) => {
   t.throws(() => parseArgs([]));
 });
 
-test.serial('parseArgs default config file valid', (t) => {
-  mockFs({
-    ['./config.json']: JSON.stringify(exampleConfig),
-  });
-  t.deepEqual(parseArgs([]), exampleConfig);
+test('parseArgs with no file', (t) => {
+  t.throws(() => parseArgs(['--config']));
 });
 
-test.serial('parseArgs custom config file does not exist', (t) => {
+test('parseArgs with environment variables and no config', (t) => {
+  const mockMgmtSvcEndpoint = 'http://localhost:8080';
+  const mockEthereumEndpoint = 'https://mainnet.infura.io/v3/1234567890';
+  const mockSignerEndpoint = 'http://localhost:8081';
+  const mockEthElectionsContract = '0x1234567890';
+  const mockNodeOrbsAddress = '555550a3c12e86b4b5f39b213f7e19d048276dae';
+
+  process.env.MANAGEMENT_SERVICE_ENDPOINT = mockMgmtSvcEndpoint;
+  process.env.ETHEREUM_ENDPOINT = mockEthereumEndpoint;
+  process.env.SIGNER_ENDPOINT = mockSignerEndpoint;
+  process.env.ETHEREUM_ELECTIONS_CONTRACT = mockEthElectionsContract;
+  process.env.NODE_ORBS_ADDRESS = mockNodeOrbsAddress;
+
+  const output = parseArgs([]);
+
+  t.notThrows(() => parseArgs([]));
+  t.assert((output.EthereumEndpoint = mockEthereumEndpoint));
+  t.assert((output.ManagementServiceEndpoint = mockMgmtSvcEndpoint));
+  t.assert((output.SignerEndpoint = mockSignerEndpoint));
+  t.assert((output.EthereumElectionsContract = mockEthElectionsContract));
+  t.assert((output.NodeOrbsAddress = mockNodeOrbsAddress));
+});
+
+test('parseArgs: errors when incomplete env vars set', (t) => {
+  const mockMgmtSvcEndpoint = 'http://localhost:8080';
+  const mockEthereumEndpoint = 'https://mainnet.infura.io/v3/1234567890';
+
+  process.env.MANAGEMENT_SERVICE_ENDPOINT = mockMgmtSvcEndpoint;
+  process.env.ETHEREUM_ENDPOINT = mockEthereumEndpoint;
+
+  t.throws(() => parseArgs([]));
+});
+
+test('parseArgs: environment variables override config file', (t) => {
+  const mockMgmtSvcEndpoint = 'http://localhost:8080';
+  const mockEthereumEndpoint = 'https://mainnet.infura.io/v3/1234567890';
+  const mockSignerEndpoint = 'http://localhost:8081';
+  const mockEthElectionsContract = '0x1234567890';
+  const mockNodeOrbsAddress = '555550a3c12e86b4b5f39b213f7e19d048276dae';
+
+  process.env.MANAGEMENT_SERVICE_ENDPOINT = mockMgmtSvcEndpoint;
+  process.env.ETHEREUM_ENDPOINT = mockEthereumEndpoint;
+  process.env.SIGNER_ENDPOINT = mockSignerEndpoint;
+  process.env.ETHEREUM_ELECTIONS_CONTRACT = mockEthElectionsContract;
+  process.env.NODE_ORBS_ADDRESS = mockNodeOrbsAddress;
+
+  mockFs({
+    ['./some/file.json']: JSON.stringify(exampleConfig),
+  });
+
+  const output = parseArgs(['--config', './some/file.json']);
+
+  t.assert((output.EthereumEndpoint = mockEthereumEndpoint));
+  t.assert((output.ManagementServiceEndpoint = mockMgmtSvcEndpoint));
+  t.assert((output.SignerEndpoint = mockSignerEndpoint));
+  t.assert((output.EthereumElectionsContract = mockEthElectionsContract));
+  t.assert((output.NodeOrbsAddress = mockNodeOrbsAddress));
+});
+
+test('parseArgs custom config file does not exist', (t) => {
   t.throws(() => parseArgs(['--config', './some/file.json']));
 });
 
-test.serial('parseArgs custom config file valid', (t) => {
+test('parseArgs custom config file valid', (t) => {
   mockFs({
     ['./some/file.json']: JSON.stringify(exampleConfig),
   });
   t.deepEqual(parseArgs(['--config', './some/file.json']), exampleConfig);
 });
 
-test.serial('parseArgs two valid custom config files merged', (t) => {
+test('parseArgs two valid custom config files merged', (t) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mergedConfig: any = _.cloneDeep(exampleConfig);
   mergedConfig.SomeField = 'some value';
@@ -41,14 +108,14 @@ test.serial('parseArgs two valid custom config files merged', (t) => {
   t.deepEqual(parseArgs(['--config', './first/file1.json', './second/file2.json']), mergedConfig);
 });
 
-test.serial('parseArgs custom config file invalid JSON format', (t) => {
+test('parseArgs custom config file invalid JSON format', (t) => {
   mockFs({
     ['./some/file.json']: JSON.stringify(exampleConfig) + '}}}',
   });
   t.throws(() => parseArgs(['--config', './some/file.json']));
 });
 
-test.serial('parseArgs custom config file missing ManagementServiceEndpoint', (t) => {
+test('parseArgs custom config file missing ManagementServiceEndpoint', (t) => {
   const partialConfig = _.cloneDeep(exampleConfig);
   delete partialConfig.ManagementServiceEndpoint;
   mockFs({

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -12,23 +12,30 @@ export function parseArgs(argv: string[]): Configuration {
       type: 'array',
       required: false,
       string: true,
-      default: ['./config.json'],
       description: 'list of config files',
     })
     .exitProcess(false)
     .parse();
 
   // read input config JSON files
+  // If config.json not provided, required config values must be passed via environment variables
   try {
     res = Object.assign(
       {},
       defaultConfiguration,
-      ...args.config.map((configPath) => JSON.parse(readFileSync(configPath).toString()))
+      ...(args.config ?? []).map((configPath) => JSON.parse(readFileSync(configPath).toString()))
     );
   } catch (err) {
     Logger.error(`Cannot parse input JSON config files: [${args.config}].`);
     throw err;
   }
+
+  // Support passing required config values via environment variables
+  res.ManagementServiceEndpoint = process.env.MANAGEMENT_SERVICE_ENDPOINT ?? res.ManagementServiceEndpoint;
+  res.EthereumEndpoint = process.env.ETHEREUM_ENDPOINT ?? res.EthereumEndpoint;
+  res.SignerEndpoint = process.env.SIGNER_ENDPOINT ?? res.SignerEndpoint;
+  res.EthereumElectionsContract = process.env.ETHEREUM_ELECTIONS_CONTRACT ?? res.EthereumElectionsContract;
+  res.NodeOrbsAddress = process.env.NODE_ORBS_ADDRESS ?? res.NodeOrbsAddress;
 
   // validate JSON config
   try {


### PR DESCRIPTION
## What's this?
Support passing required config values via environment variables (needed for v3 architecture), in addition to config file.

## Testing

### Unit tests
Run `npx ava --verbose --timeout=10m --serial --fail-fast src/cli-args.test.ts `

### Running locally
#### No config file and no environment variables
1. Run `npx tsc --skipLibCheck -p ./tsconfig.prod.json && npm run start`

#### Environment variables and no config file
1.  Add the following env vars:
```
export MANAGEMENT_SERVICE_ENDPOINT=http://adasdds.com
export ETHEREUM_ENDPOINT=http://adasdds.com
export SIGNER_ENDPOINT=http://adasdds.com
export ETHEREUM_ELECTIONS_CONTRACT=0xblah
export NODE_ORBS_ADDRESS=555550a3c12e86b4b5f39b213f7e19d048276dae
```
2. Run `npx tsc --skipLibCheck -p ./tsconfig.prod.json && npm run start`

#### Config file and no environment variables
1. Ensure previous env vars are not set:
```
unset MANAGEMENT_SERVICE_ENDPOINT
unset ETHEREUM_ENDPOINT
unset SIGNER_ENDPOINT
unset ETHEREUM_ELECTIONS_CONTRACT
unset NODE_ORBS_ADDRESS

```
2. Create `config.json` in root of project with following:
```
{
  "EthereumElectionsContract": "0xblah",
  "EthereumEndpoint": "http://adasdds.com",
  "ManagementServiceEndpoint": "http://adasdds.com",
  "NodeOrbsAddress": "555550a3c12e86b4b5f39b213f7e19d048276dae",
  "SignerEndpoint": "http://adasdds.com"
}
```
3. Run `npx tsc --skipLibCheck -p ./tsconfig.prod.json && npm run start -- --config ./config.json`
